### PR TITLE
Game speed

### DIFF
--- a/root/scripts/game.js
+++ b/root/scripts/game.js
@@ -199,11 +199,11 @@ function run_game(){
     }
 
     scroll_world();
+
     remove_elapsed_platforms();
     buffer_new_platforms();
     render_platforms();
 
-    scroll_powerups();
     remove_elapsed_powerups();
     buffer_new_powerups();
     apply_powerup();
@@ -327,16 +327,6 @@ function apply_powerup(){
 
     // Call powerup type function with factor to apply the powerup
     powerup_types[powerup.type].func(powerup.factor);
-}
-
-function scroll_powerups(){
-    var current_speed =  scroll_speed_base + elapsed_time/scroll_speed_update_time;
-    if (current_speed > max_scroll_speed){
-        current_speed = max_scroll_speed;
-    }
-    powerups.map(function(powerup){
-        powerup.x = powerup.x - current_speed;
-    })
 }
 
 function render_powerups(){
@@ -508,6 +498,9 @@ function scroll_world(){
     }
     platforms.map(function(platform){
         platform.x = platform.x - current_speed;
+    })
+    powerups.map(function(powerup){
+        powerup.x = powerup.x - current_speed;
     })
 }
 


### PR DESCRIPTION
The game play speed has been updated by refactoring the following settings:
- scroll_speed
- platform_separation
## Scroll speed
- The scroll speed controls the horizontal movement of the platforms
- The base scroll speed is set to 2 and is increased every 27.5sec by 1 until the maximum of 8 is reached
- A maximum was decided because if it goes past the maximum it would be impossible to play and the game ends quickly
- The update time was chosen to be 27.5sec after heavy testing for the ideal speed :+1: 
## Platform separation
- The platform separation is the horizontal distance between platforms
- The base separation multiplier is set to 50 and starts off with a min and max separation of the base separation multiplier
- The min and max separation is updated every 30sec
- The max separation that can be reached is 300 as the canvas width is 700 and anything more than 300 would make only one platform appear when it exceeds 300
- When the min and max separation is updated the new min is set as the old max and the new max is set as the old max + base separation multiplier
- The x_distance is a random int between the min and max separation. This makes it more challenging and the platform map look much neater
  
  Also the min and max platform width have been optimized for perfects settings!
