### PR TITLE
Powerups tweak

### DIFF
--- a/root/scripts/game.js
+++ b/root/scripts/game.js
@@ -107,16 +107,14 @@ function initialise(){
             colour: "blue",
             func: apply_gravity,
             width: 30,
-            height: 30,
-            factor: createRangeArray(0.5, 0.7, 9).reverse()
+            height: 30
         },
         points_multiplier:{
             label: "Points Multiplier",
             colour: "red",
             func: apply_points_multiplier,
             width: 20,
-            height: 20,
-            factor: createRangeArray(2, 10, 9)
+            height: 20
         },
     }
 
@@ -228,15 +226,6 @@ function getRandomInt(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-function createRangeArray(min, max, length){
-    var dif = (max - min) / (length - 1);
-    var factor_array = [min];
-    for (var i=1; i<length; i++){
-        factor_array.push(factor_array[i-1]+dif);
-    }
-    return factor_array;
-}
-
 function render_player(){
     if (Math.floor(player.vel_y) != 0){
         ctx.drawImage(player_jumping, player.x, player.y, player.width, player.height);
@@ -262,7 +251,7 @@ function buffer_new_powerups(){
                 y: rnd_platform.y - powerup_types[rnd_type].height,
                 type: rnd_type,
                 time: getRandomInt(3, max_powerup_time),
-                factor_id: getRandomInt(0,8)
+                factor: Math.random()*9+1 
             }
         )
         next_powerup_in += 0.02;
@@ -278,7 +267,8 @@ function remove_elapsed_powerups(){
 
 function apply_gravity(factor){
     if(factor){
-        gravity = factor;
+        var dif = 0.8 - 0.5;
+        gravity = 0.8 - ((dif * factor)/10);
     }else{
         gravity = 0.8;
     }
@@ -325,7 +315,7 @@ function render_powerup_timer(){
     ctx.fillStyle = points_colour;
     ctx.textAlign="end";
     ctx.fillText("Powerup Active: " + powerup_types[powerup_active.type].label, width, 60);
-    ctx.fillText("Multiplier: " + powerup_types[powerup_active.type].factor[powerup_active.factor_id], width, 90);
+    ctx.fillText("Multiplier: " + powerup_active.factor, width, 90);
     ctx.fillText("Time Left: " + time, width, 120);
 }
 
@@ -341,7 +331,7 @@ function apply_powerup(){
     powerup_started_time = new Date().getTime();
 
     // Call powerup type function with factor to apply the powerup
-    powerup_types[powerup.type].func(powerup_types[powerup.type].factor[powerup_active.factor_id]);
+    powerup_types[powerup.type].func(powerup_active.factor);
 }
 
 function render_powerups(){


### PR DESCRIPTION
///////////////////////////////////////////////////////////////////////////////////////////
///////**Please merge game-speed before merging this**/////////
///////////////////////////////////////////////////////////////////////////////////////////

Consider t as the time taken to generate the next powerup
Powerups are generated every t secs where t is increased by 0.6sec after a powerup is generated.
t initially is 6.4sec

The time for a powerup lasting is set to a number ranging between 3 and 6 (this is because its an ideal value and anything less or more than would be unfair and hard to control)

The factor of the powerup is set to a constant value as it would be sensible that way:
- gravity was earlier ranging from 0 to 2 and anything higher than 0.8 wouldn't imply less gravity and  less than 0.5 would be very hard to control.
- points multiplier should be set to a constant as it would not be fair to everyone playing the game. Some might never get a higher multiplier.

Factor is removed from the buffer_new_powerups as it can got from the powerup_types
