### PR TITLE
Fixed bug when auth_token cookie doesn't exist

### DIFF
--- a/root/app/middleware.js
+++ b/root/app/middleware.js
@@ -4,8 +4,15 @@ var config = require('../config/database');
 
 exports.get_user = function(req, res, next){
     console.log('in get user')
-    var token = req.cookies.auth_token.split(' ')[1];
     res.locals.user = undefined;
+    var cookie = req.cookies.auth_token;
+    var token = undefined;
+    if(cookie){
+        var token_pieces = cookie.split(' ')
+        if(token_pieces.length == 2){
+            token = token_pieces[1];
+        }
+    }
     if (token) {
         var decoded = jwt.decode(token, config.secret);
         User.findOne({


### PR DESCRIPTION
It was pretty broken

Good find wimo :)

I now check that the token exists first
Then I check if It can be safely split into two before I access the second part

The reason this was broken before is the token should look like this
"JWT nosuhsnoaehuntumnsoaethkar}+g}ruchha{[l]uh}l+k)......."
And the part after the JWT is the actual token
BUT the token may be undefined if the user hasn't loaded the page before
and so splitting on (' ') and getting the 2nd element doesn't work
